### PR TITLE
Create Selling Plan Group V2

### DIFF
--- a/app/server/controllers/subscriptions.ts
+++ b/app/server/controllers/subscriptions.ts
@@ -8,6 +8,7 @@ import {
   removeProductVariantFromSellingPlanGroups,
   createClient,
   createSellingPlanGroup,
+  createSellingPlanGroupV2,
   updateSellingPlanGroup,
   deleteSellingPlanGroup,
   getSellingPlans,
@@ -91,6 +92,24 @@ export const createSubscriptionPlanGroup = async (ctx: Context) => {
     if (res) {
       ctx.client = createClient(shop, res.accessToken);
       const id = await createSellingPlanGroup(ctx);
+      ctx.body = id;
+    } else {
+      return (ctx.status = 401);
+    }
+  } catch (err: any) {
+    logger.log('error', err.message);
+    return (ctx.status = 500);
+  }
+};
+
+export const createSubscriptionPlanGroupV2 = async (ctx: Context) => {
+  try {
+    const shop = ctx.state.shop;
+    // this will have to call db and get accessToken
+    const res = await pgStorage.loadCurrentShop(shop);
+    if (res) {
+      ctx.client = createClient(shop, res.accessToken);
+      const id = await createSellingPlanGroupV2(ctx);
       ctx.body = id;
     } else {
       return (ctx.status = 401);

--- a/app/server/handlers/index.ts
+++ b/app/server/handlers/index.ts
@@ -2,6 +2,7 @@ import { createClient } from './client';
 import { getOneTimeUrl } from './mutations/get-one-time-url';
 import { getSubscriptionUrl } from './mutations/get-subscription-url';
 import { createSellingPlanGroup } from './mutations/create-selling-plan-group';
+import { createSellingPlanGroupV2 } from './mutations/create-selling-plan-group-v2';
 import { addProductToSellingPlanGroups } from './mutations/add-product-to-selling-plan-groups';
 import { addProductVariantToSellingPlanGroups } from './mutations/add-product-variant-to-selling-plan-groups';
 import { removeProductsFromSellingPlanGroup } from './mutations/remove-products-from-selling-plan-group';
@@ -26,6 +27,7 @@ export {
   getOneTimeUrl,
   getSubscriptionUrl,
   createSellingPlanGroup,
+  createSellingPlanGroupV2,
   addProductToSellingPlanGroups,
   addProductVariantToSellingPlanGroups,
   removeProductsFromSellingPlanGroup,

--- a/app/server/handlers/mutations/create-selling-plan-group-v2.ts
+++ b/app/server/handlers/mutations/create-selling-plan-group-v2.ts
@@ -99,7 +99,7 @@ const createInput = (body: Body) => {
           },
         ],
       };
-      sellingPlans.push(plans);
+      plans.push(sellingPlan);
     }
   }
 
@@ -111,7 +111,7 @@ const createInput = (body: Body) => {
       description: planGroupDescription,
       options: [planGroupOption], // 'Delivery every'
       position: 1,
-      sellingPlansToCreate: sellingPlans,
+      sellingPlansToCreate: plans,
     },
   };
   return variables;

--- a/app/server/handlers/mutations/create-selling-plan-group-v2.ts
+++ b/app/server/handlers/mutations/create-selling-plan-group-v2.ts
@@ -3,7 +3,7 @@ import { gql } from '@apollo/client';
 import { Context } from 'koa';
 
 interface Body {
-  planTitle: string;
+  planGroupName: string;
   merchantCode: string;
   numberOfPlans: string;
   planGroupOption: string;
@@ -36,7 +36,7 @@ const cleanInterval = (interval: string) => {
 
 const createInput = (body: Body) => {
   const {
-    planTitle,
+    planGroupName,
     merchantCode,
     numberOfPlans,
     planGroupOption,
@@ -47,10 +47,9 @@ const createInput = (body: Body) => {
   // Set number of plans
   let plans: any[] = [];
   const planCount = parseInt(numberOfPlans);
-
   if (planCount > 1) {
     for (let i = 1; i <= planCount; i++) {
-      const currentPlan = sellingPlans[i];
+      const currentPlan = sellingPlans[i.toString()];
       // Set interval for naming
       const intervalTitle = cleanInterval(currentPlan.intervalOption);
       // savings
@@ -106,7 +105,7 @@ const createInput = (body: Body) => {
   const variables = {
     input: {
       appId: '4975729',
-      name: planTitle,
+      name: planGroupName,
       merchantCode: merchantCode, // 'subscribe-and-save'
       description: planGroupDescription,
       options: [planGroupOption], // 'Delivery every'
@@ -134,6 +133,7 @@ export const createSellingPlanGroupV2 = async (ctx: Context) => {
             sellingPlanGroup: {
               id: string;
             };
+            userErrors?: any;
           };
         };
       }) => {

--- a/app/server/handlers/mutations/create-selling-plan-group-v2.ts
+++ b/app/server/handlers/mutations/create-selling-plan-group-v2.ts
@@ -1,0 +1,145 @@
+import 'isomorphic-fetch';
+import { gql } from '@apollo/client';
+import { Context } from 'koa';
+
+interface Body {
+  planTitle: string;
+  merchantCode: string;
+  numberOfPlans: string;
+  planGroupOption: string;
+  planGroupDescription: string;
+  sellingPlans: any;
+}
+
+export function SELLING_PLAN_CREATE() {
+  return gql`
+    mutation sellingPlanGroupCreate($input: SellingPlanGroupInput!) {
+      sellingPlanGroupCreate(input: $input) {
+        sellingPlanGroup {
+          id
+        }
+        userErrors {
+          code
+          field
+          message
+        }
+      }
+    }
+  `;
+}
+
+const cleanInterval = (interval: string) => {
+  interval = interval.toLowerCase();
+  const cap = interval.substr(0, 1);
+  return `${cap.toUpperCase()}${interval.substr(1)}`;
+};
+
+const createInput = (body: Body) => {
+  const {
+    planTitle,
+    merchantCode,
+    numberOfPlans,
+    planGroupOption,
+    planGroupDescription,
+    sellingPlans,
+  } = body;
+
+  // Set number of plans
+  let plans: any[] = [];
+  const planCount = parseInt(numberOfPlans);
+
+  if (planCount > 1) {
+    for (let i = 1; i <= planCount; i++) {
+      const currentPlan = sellingPlans[i];
+      // Set interval for naming
+      const intervalTitle = cleanInterval(currentPlan.intervalOption);
+      // savings
+      let savingsDescription: string = '';
+      let savingsName: string = '';
+      if (parseInt(currentPlan.percentageOff) > 0) {
+        savingsDescription = `, save ${currentPlan.percentageOff}% on every order`;
+        savingsName = ` (Save ${currentPlan.percentageOff}%)`;
+      }
+      let deliveryOption: string = `Delivered every `;
+      if (currentPlan.intervalCount > 1) {
+        deliveryOption = `${deliveryOption}${currentPlan.intervalCount} `;
+      }
+      deliveryOption = `${deliveryOption}${intervalTitle}`;
+      if (currentPlan.intervalCount > 1) {
+        deliveryOption = `${deliveryOption}s`;
+      }
+
+      const planName = `${deliveryOption}${savingsName}`;
+
+      let sellingPlan = {
+        name: planName,
+        description: `${deliveryOption}${savingsDescription}. Auto renews, skip, cancel anytime.`,
+        options: deliveryOption,
+        position: currentPlan.id,
+        billingPolicy: {
+          recurring: {
+            interval: currentPlan.intervalOption,
+            intervalCount: parseInt(currentPlan.intervalCount),
+          },
+        },
+        deliveryPolicy: {
+          recurring: {
+            interval: currentPlan.intervalOption,
+            intervalCount: parseInt(currentPlan.intervalCount),
+          },
+        },
+        pricingPolicies: [
+          {
+            fixed: {
+              adjustmentType: 'PERCENTAGE',
+              adjustmentValue: {
+                percentage: parseInt(currentPlan.percentageOff),
+              },
+            },
+          },
+        ],
+      };
+      sellingPlans.push(plans);
+    }
+  }
+
+  const variables = {
+    input: {
+      appId: '4975729',
+      name: planTitle,
+      merchantCode: merchantCode, // 'subscribe-and-save'
+      description: planGroupDescription,
+      options: [planGroupOption], // 'Delivery every'
+      position: 1,
+      sellingPlansToCreate: sellingPlans,
+    },
+  };
+  return variables;
+};
+
+export const createSellingPlanGroupV2 = async (ctx: Context) => {
+  const { client } = ctx;
+  const body = ctx.request.body as any;
+  // create input
+  const variables = createInput(body);
+  const sellingPlanGroupId = await client
+    .mutate({
+      mutation: SELLING_PLAN_CREATE(),
+      variables: variables,
+    })
+    .then(
+      (response: {
+        data: {
+          sellingPlanGroupCreate: {
+            sellingPlanGroup: {
+              id: string;
+            };
+          };
+        };
+      }) => {
+        return response.data.sellingPlanGroupCreate.sellingPlanGroup.id;
+      }
+    );
+
+  return sellingPlanGroupId;
+};

--- a/app/server/routes/subscriptions.ts
+++ b/app/server/routes/subscriptions.ts
@@ -6,6 +6,7 @@ import {
   getAllSubscriptionGroups,
   addProductToSubscriptionPlanGroup,
   createSubscriptionPlanGroup,
+  createSubscriptionPlanGroupV2,
   editSubscriptionPlanGroup,
   removeProductFromSubscriptionPlanGroup,
   deleteSubscriptionPlanGroup,
@@ -51,6 +52,12 @@ router.post(
   '/subscription-plan/create',
   verifyJwt,
   createSubscriptionPlanGroup
+);
+
+router.post(
+  '/subscription-plan/v2/create',
+  verifyJwt,
+  createSubscriptionPlanGroupV2
 );
 
 router.post('/subscription-plan/edit', verifyJwt, editSubscriptionPlanGroup);

--- a/app/server/routes/subscriptions.ts
+++ b/app/server/routes/subscriptions.ts
@@ -51,7 +51,7 @@ router.post(
 router.post(
   '/subscription-plan/create',
   verifyJwt,
-  createSubscriptionPlanGroup
+  createSubscriptionPlanGroupV2
 );
 
 router.post(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,22 +30,22 @@ services:
     networks:
       - default
   # app
-  suavescribe:
-    image: 'jriv/suavescribe:latest'
-    container_name: 'suavescribe'
-    restart: always
-    ports:
-      - 8081:8081
-    volumes:
-      - './app:/usr/app'
-    depends_on:
-      - redis
-      - postgres
-    links:
-      - redis
-      - postgres
-    networks:
-      - default
+  # suavescribe:
+  #   image: 'jriv/suavescribe:latest'
+  #   container_name: 'suavescribe'
+  #   restart: always
+  #   ports:
+  #     - 8081:8081
+  #   volumes:
+  #     - './app:/usr/app'
+  #   depends_on:
+  #     - redis
+  #     - postgres
+  #   links:
+  #     - redis
+  #     - postgres
+  #   networks:
+  #     - default
 
 networks:
   default:


### PR DESCRIPTION
# Updates
- Added route / controller for creating selling plan groups with a dynamic amount of selling plans. Selling plans are limited to adjustment pricing policies of type percentage for now. For my use case this is all I need.
- App extension will be updated to take user input for these new selling plans.