### PR TITLE
Updated edit selling plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ data/traefik
 app/app_proxy/*
 
 NOTES.md
+CHANGES.md

--- a/README.md
+++ b/README.md
@@ -117,10 +117,15 @@ certificatesResolvers:
         entryPoint: insecure
 
 ```
-
 Run
 ```bash
 docker-compose up -d
+```
+
+```bash
+# to remove docker containers
+# --volumes to remove volumes
+docker system prune
 ```
 
 ## Logs

--- a/app/server/routes/subscriptions.ts
+++ b/app/server/routes/subscriptions.ts
@@ -51,7 +51,7 @@ router.post(
 router.post(
   '/subscription-plan/create',
   verifyJwt,
-  createSubscriptionPlanGroupV2
+  createSubscriptionPlanGroup
 );
 
 router.post(

--- a/app/src/components/UpdateSellingPlanForm.tsx
+++ b/app/src/components/UpdateSellingPlanForm.tsx
@@ -1,0 +1,145 @@
+import React, { useState } from 'react';
+import { Card, Layout, Select, TextField } from '@shopify/polaris';
+import { SellingPlan } from '../types/sellingplans';
+
+interface Props {
+  sellingPlan: SellingPlan;
+  handleSellingPlans: (id: string, sellingPlan: any) => void;
+  index: number;
+}
+
+function UpdateSellingPlanForm(props: Props) {
+  const { sellingPlan, handleSellingPlans, index } = props;
+  const plan = sellingPlan.node;
+  const planId = plan.id;
+  // inital state values
+  const initialName = plan.name;
+  const initialOptions = plan.options[0];
+  const initialIntervalOption = plan.billingPolicy.interval;
+  const initialIntervalCount = plan.billingPolicy.intervalCount.toString();
+  const initialDiscountPercentage =
+    plan.pricingPolicies[0].adjustmentValue.percentage.toString();
+
+  const [planName, setPlanName] = useState<string>(initialName);
+  const [planOptions, setPlanOptions] = useState<string>(initialOptions);
+  const [planIntervalOption, setPlanIntervalOption] = useState<string>(
+    initialIntervalOption
+  );
+  const [planIntervalCount, setPlanIntervalCount] =
+    useState<string>(initialIntervalCount);
+  const [intervalCount, setIntervalCount] =
+    useState<string>(initialIntervalCount);
+  const [percentOff, setPercentOff] = useState<string>(
+    initialDiscountPercentage
+  );
+
+  const handlePlanName = (name: string) => {
+    setPlanName(name);
+    handleSellingPlans(planId, {
+      name: name,
+      options: planOptions,
+      interval: planIntervalOption,
+      intervalCount: parseInt(planIntervalCount),
+      percentOff: parseInt(percentOff),
+    });
+  };
+
+  const handlePlanOptions = (options: string) => {
+    setPlanOptions(options);
+    handleSellingPlans(planId, {
+      name: planName,
+      options: options,
+      interval: planIntervalOption,
+      intervalCount: parseInt(planIntervalCount),
+      percentOff: parseInt(percentOff),
+    });
+  };
+
+  const handleIntervalOption = (option: string) => {
+    setPlanIntervalOption(option);
+    handleSellingPlans(planId, {
+      name: planName,
+      options: planOptions,
+      interval: option,
+      intervalCount: parseInt(planIntervalCount),
+      percentOff: parseInt(percentOff),
+    });
+  };
+
+  const handleIntervalCount = (count: string) => {
+    setPlanIntervalCount(count);
+    handleSellingPlans(planId, {
+      name: planName,
+      options: planOptions,
+      interval: planIntervalOption,
+      intervalCount: parseInt(count),
+      percentOff: parseInt(percentOff),
+    });
+  };
+
+  const handlePercentOff = (percent: string) => {
+    setPercentOff(percent);
+    handleSellingPlans(planId, {
+      name: planName,
+      options: planOptions,
+      interval: planIntervalOption,
+      intervalCount: parseInt(planIntervalCount),
+      percentOff: parseInt(percent),
+    });
+  };
+
+  return (
+    <Card title={`Selling Plan ${index + 1}`} sectioned>
+      <Layout>
+        <Layout.Section>
+          <TextField
+            value={planName}
+            onChange={value => handlePlanName(value)}
+            label="Plan Name"
+            type="text"
+          />
+          <TextField
+            value={planOptions}
+            onChange={value => handlePlanOptions(value)}
+            label="Options"
+            type="text"
+          />
+        </Layout.Section>
+        <Layout.Section>
+          <Select
+            label="Interval"
+            options={[
+              { label: 'Daily', value: 'DAY' },
+              { label: 'Weekly', value: 'WEEK' },
+              { label: 'Monthly', value: 'MONTH' },
+              { label: 'Yearly', value: 'YEAR' },
+            ]}
+            onChange={value => handleIntervalOption(value)}
+            value={planIntervalOption}
+          />
+          <Select
+            label="Interval Count"
+            options={Array.from({ length: 9 }, (_, i) => i + 1).map(
+              (i: number) => {
+                return {
+                  label: `${i}`,
+                  value: `${i}`,
+                };
+              }
+            )}
+            onChange={value => handleIntervalCount(value)}
+            value={planIntervalCount}
+          />
+          <TextField
+            value={percentOff}
+            onChange={value => handlePercentOff(value)}
+            label="Percent Off (%)"
+            type="number"
+          />
+        </Layout.Section>
+      </Layout>
+    </Card>
+  );
+}
+
+export default UpdateSellingPlanForm;

--- a/app/src/components/UpdateSellingPlanGroupButton.tsx
+++ b/app/src/components/UpdateSellingPlanGroupButton.tsx
@@ -7,8 +7,8 @@ interface Props {
   id: string;
   groupName: string;
   groupDescription: string;
+  groupOptions: string[];
   merchantCode: string;
-  options: string;
   sellingPlans: any[];
   toggleActive: () => void;
   setMsg: (msg: string) => void;
@@ -91,8 +91,13 @@ const cleanInterval = (interval: string) => {
 };
 
 const createInput = (props: Props) => {
-  const { groupName, groupDescription, merchantCode, options, sellingPlans } =
-    props;
+  const {
+    groupName,
+    groupDescription,
+    merchantCode,
+    groupOptions,
+    sellingPlans,
+  } = props;
 
   // TODO SET GROUP INPUTS HERE, ALSO DEAL WITH UPDATING DESCRIPTION BASED ON NEW INPUTS
 
@@ -142,7 +147,7 @@ const createInput = (props: Props) => {
     name: groupName,
     merchantCode: merchantCode, // 'subscribe-and-save'
     description: groupDescription,
-    options: [options], // 'Delivery every'
+    options: [...groupOptions], // 'Delivery every'
     position: 1,
     sellingPlansToUpdate: plans,
   };

--- a/app/src/components/UpdateSellingPlanGroupButton.tsx
+++ b/app/src/components/UpdateSellingPlanGroupButton.tsx
@@ -110,7 +110,7 @@ const createInput = (props: Props) => {
     }
     let sellingPlan: SellingPlan = {
       id: plan.node.id,
-      name: planName,
+      name: planName, // plan.node.name makes this use user input, right now it's being overwritten for better naming
       description: `${deliveryOption}, save ${percentage}% on every order. Auto renews, skip, cancel anytime.`,
       options: plan.node.options[0],
       position: plan.node.position,

--- a/app/src/components/UpdateSellingPlanGroupButton.tsx
+++ b/app/src/components/UpdateSellingPlanGroupButton.tsx
@@ -5,10 +5,9 @@ import { UPDATE_SELLING_PLAN_GROUP } from '../handlers';
 
 interface Props {
   id: string;
-  planTitle: string;
-  percentOff: string;
+  groupName: string;
+  groupDescription: string;
   merchantCode: string;
-  interval: string;
   options: string;
   sellingPlans: any[];
   toggleActive: () => void;
@@ -71,6 +70,7 @@ function UpdateSellingPlanGroupButton(props: Props) {
         },
       });
     } catch (e) {
+      console.log('ERROR', e.message);
       setToastError(true);
       setMsg('Error Updating Selling Plan Group');
       toggleActive();
@@ -91,41 +91,46 @@ const cleanInterval = (interval: string) => {
 };
 
 const createInput = (props: Props) => {
-  const {
-    planTitle,
-    percentOff,
-    merchantCode,
-    interval,
-    options,
-    sellingPlans,
-  } = props;
+  const { groupName, groupDescription, merchantCode, options, sellingPlans } =
+    props;
+
+  // TODO SET GROUP INPUTS HERE, ALSO DEAL WITH UPDATING DESCRIPTION BASED ON NEW INPUTS
+
   // Set interval for naming
-  const intervalTitle = cleanInterval(interval);
   const plans: SellingPlan[] = [];
   sellingPlans.forEach(plan => {
-    let deliveryOption = `Delivered every ${plan.node.position} ${intervalTitle}s`;
-    let planName = `${deliveryOption} (Save ${percentOff}%)`;
+    // Set interval for naming
+    const intervalTitle = cleanInterval(plan.node.billingPolicy.interval);
+    const percentage = plan.node.pricingPolicies[0].adjustmentValue.percentage;
+    let deliveryOption = `Delivered every ${plan.node.billingPolicy.intervalCount} ${intervalTitle}s`;
+    let planName = `${deliveryOption} (Save ${percentage}%)`;
     if (plan.node.position === 1) {
       deliveryOption = `Delivered every ${intervalTitle}`;
-      planName = `${deliveryOption} (Save ${percentOff}%)`;
+      planName = `${deliveryOption} (Save ${percentage}%)`;
     }
     let sellingPlan: SellingPlan = {
       id: plan.node.id,
       name: planName,
-      description: `${deliveryOption}, save ${percentOff}% on every order. Auto renews, skip, cancel anytime.`,
-      options: deliveryOption,
+      description: `${deliveryOption}, save ${percentage}% on every order. Auto renews, skip, cancel anytime.`,
+      options: plan.node.options[0],
       position: plan.node.position,
       billingPolicy: {
-        recurring: { interval: interval, intervalCount: plan.node.position },
+        recurring: {
+          interval: plan.node.billingPolicy.interval,
+          intervalCount: plan.node.billingPolicy.intervalCount,
+        },
       },
       deliveryPolicy: {
-        recurring: { interval: interval, intervalCount: plan.node.position },
+        recurring: {
+          interval: plan.node.deliveryPolicy.interval,
+          intervalCount: plan.node.deliveryPolicy.intervalCount,
+        },
       },
       pricingPolicies: [
         {
           fixed: {
             adjustmentType: 'PERCENTAGE',
-            adjustmentValue: { percentage: parseFloat(percentOff) },
+            adjustmentValue: { percentage: percentage },
           },
         },
       ],
@@ -134,9 +139,9 @@ const createInput = (props: Props) => {
   });
   const input = {
     appId: '4975729',
-    name: planTitle,
+    name: groupName,
     merchantCode: merchantCode, // 'subscribe-and-save'
-    description: `Delivered at ${intervalTitle}ly intervals at ${percentOff}% discount.`,
+    description: groupDescription,
     options: [options], // 'Delivery every'
     position: 1,
     sellingPlansToUpdate: plans,

--- a/app/src/handlers/queries/get-selling-plan-group-by-id.ts
+++ b/app/src/handlers/queries/get-selling-plan-group-by-id.ts
@@ -6,6 +6,7 @@ export const GET_SELLING_PLAN_GROUP_BY_ID = gql`
       id
       name
       summary
+      description
       merchantCode
       productCount
       productVariantCount
@@ -31,6 +32,12 @@ export const GET_SELLING_PLAN_GROUP_BY_ID = gql`
                     percentage
                   }
                 }
+              }
+            }
+            deliveryPolicy {
+              ... on SellingPlanRecurringDeliveryPolicy {
+                interval
+                intervalCount
               }
             }
           }

--- a/app/src/pages/selling-plan-group.tsx
+++ b/app/src/pages/selling-plan-group.tsx
@@ -5,7 +5,6 @@ import {
   Frame,
   Layout,
   Page,
-  Select,
   TextField,
   TextStyle,
   Thumbnail,
@@ -69,9 +68,10 @@ function SellingPlanGroup() {
   // state
   const [groupName, setGroupName] = useState<string>();
   const [groupDescription, setGroupDescription] = useState<string>();
+  const [groupOptions, setGroupOptions] = useState<string[]>();
+  const [options, setOptions] = useState<string>();
   const [merchantCode, setMerchantCode] = useState<string>();
   const [sellingPlans, setSellingPlans] = useState<SellingPlan[]>([]);
-  const [options, setOptions] = useState<string>();
 
   const [active, setActive] = useState<boolean>(false);
   const [toastMsg, setToastMsg] = useState<string>('');
@@ -93,8 +93,19 @@ function SellingPlanGroup() {
     setMerchantCode(merchantCode);
   };
 
+  const handleGroupOptions = (options: string) => {
+    let opts: string[] = [];
+    if (options.includes(',')) {
+      opts = options.split(',');
+      opts = opts.map((el: string) => el.trim());
+    } else {
+      opts = [options];
+    }
+    setOptions(options);
+    setGroupOptions(opts);
+  };
+
   const handleSellingPlans = (id: string, sellingPlan: any) => {
-    console.log(`Updating id: ${id} with`, sellingPlan);
     const updatedSellingPlans = sellingPlans.map((plan: any) => {
       if (plan.node.id === id) {
         const updatedPlan = {
@@ -124,7 +135,6 @@ function SellingPlanGroup() {
       }
       return plan;
     });
-    console.log('UPDATED SELLING PLANS', updatedSellingPlans);
     setSellingPlans(updatedSellingPlans);
   };
 
@@ -146,15 +156,13 @@ function SellingPlanGroup() {
       onCompleted: data => {
         if (data.sellingPlanGroup) {
           const sellingPlanGroup = data.sellingPlanGroup;
-          // new
           const plans = sellingPlanGroup.sellingPlans.edges;
-          console.log('SELLING PLANS', plans);
-          const sellingPlan = sellingPlanGroup.sellingPlans.edges[0];
           setGroupName(sellingPlanGroup.name);
           setGroupDescription(sellingPlanGroup.description);
           setMerchantCode(sellingPlanGroup.merchantCode);
           setSellingPlans(plans);
-          setOptions(sellingPlanGroup.options[0]);
+          setOptions(sellingPlanGroup.options.toString());
+          setGroupOptions([...sellingPlanGroup.options]);
         }
       },
     }
@@ -306,6 +314,12 @@ function SellingPlanGroup() {
                       label="Merchant Code"
                       type="text"
                     />
+                    <TextField
+                      value={options}
+                      onChange={value => handleGroupOptions(value)}
+                      label="Group Options"
+                      type="text"
+                    />
                   </Layout.Section>
                 </Layout>
               </Card>
@@ -325,8 +339,8 @@ function SellingPlanGroup() {
                 id={data.sellingPlanGroup.id}
                 groupName={groupName}
                 groupDescription={groupDescription}
+                groupOptions={groupOptions}
                 merchantCode={merchantCode}
-                options={options}
                 sellingPlans={sellingPlans}
                 toggleActive={toggleActive}
                 setMsg={setMsg}

--- a/app/src/pages/selling-plan-group.tsx
+++ b/app/src/pages/selling-plan-group.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import {
   Card,
@@ -18,10 +18,12 @@ import { Redirect } from '@shopify/app-bridge/actions';
 import {
   GET_SELLING_PLAN_GROUP_BY_ID,
   DELETE_SELLING_PLAN_GROUP,
+  GET_ALL_SELLING_PLAN_GROUPS,
 } from '../handlers';
 import { formatId } from '../utils/formatters';
 import LoadingSellingPlan from '../components/LoadingSellingPlan';
 import ErrorState from '../components/ErrorState';
+import UpdateSellingPlanForm from '../components/UpdateSellingPlanForm';
 import UpdateSellingPlanGroupButton from '../components/UpdateSellingPlanGroupButton';
 import {
   Product as ShopifyProduct,
@@ -65,15 +67,66 @@ function SellingPlanGroup() {
     );
 
   // state
-  const [planTitle, setPlanTitle] = useState<string>();
+  const [groupName, setGroupName] = useState<string>();
+  const [groupDescription, setGroupDescription] = useState<string>();
   const [merchantCode, setMerchantCode] = useState<string>();
+  const [sellingPlans, setSellingPlans] = useState<SellingPlan[]>([]);
   const [options, setOptions] = useState<string>();
-  const [interval, setInterval] = useState<string>();
-  const [percentOff, setPercentOff] = useState<string>();
 
   const [active, setActive] = useState<boolean>(false);
   const [toastMsg, setToastMsg] = useState<string>('');
   const [isError, setIsError] = useState<boolean>(false);
+
+  useEffect(() => {
+    console.log('CHANGES TO SELLING PLANS', sellingPlans);
+  }, [sellingPlans]);
+
+  const handleGroupName = (name: string) => {
+    setGroupName(name);
+  };
+
+  const handleGroupDescription = (description: string) => {
+    setGroupDescription(description);
+  };
+
+  const handleMerchantCode = (merchantCode: string) => {
+    setMerchantCode(merchantCode);
+  };
+
+  const handleSellingPlans = (id: string, sellingPlan: any) => {
+    console.log(`Updating id: ${id} with`, sellingPlan);
+    const updatedSellingPlans = sellingPlans.map((plan: any) => {
+      if (plan.node.id === id) {
+        const updatedPlan = {
+          node: {
+            ...plan.node,
+            name: sellingPlan.name,
+            options: [sellingPlan.options],
+            billingPolicy: {
+              interval: sellingPlan.interval,
+              intervalCount: sellingPlan.intervalCount,
+            },
+            deliveryPolicy: {
+              interval: sellingPlan.interval,
+              intervalCount: sellingPlan.intervalCount,
+            },
+            pricingPolicies: [
+              {
+                adjustmentType: 'PERCENTAGE',
+                adjustmentValue: {
+                  percentage: sellingPlan.percentOff,
+                },
+              },
+            ],
+          },
+        };
+        return updatedPlan;
+      }
+      return plan;
+    });
+    console.log('UPDATED SELLING PLANS', updatedSellingPlans);
+    setSellingPlans(updatedSellingPlans);
+  };
 
   // Toast
   const toggleActive = useCallback(() => setActive(active => !active), []);
@@ -93,16 +146,15 @@ function SellingPlanGroup() {
       onCompleted: data => {
         if (data.sellingPlanGroup) {
           const sellingPlanGroup = data.sellingPlanGroup;
+          // new
+          const plans = sellingPlanGroup.sellingPlans.edges;
+          console.log('SELLING PLANS', plans);
           const sellingPlan = sellingPlanGroup.sellingPlans.edges[0];
-          const interval = sellingPlan.node.billingPolicy.interval;
-          const percentage = String(
-            sellingPlan.node.pricingPolicies[0].adjustmentValue.percentage
-          );
-          setPlanTitle(sellingPlanGroup.name);
+          setGroupName(sellingPlanGroup.name);
+          setGroupDescription(sellingPlanGroup.description);
           setMerchantCode(sellingPlanGroup.merchantCode);
+          setSellingPlans(plans);
           setOptions(sellingPlanGroup.options[0]);
-          setInterval(interval);
-          setPercentOff(percentage);
         }
       },
     }
@@ -177,7 +229,7 @@ function SellingPlanGroup() {
                   {data.sellingPlanGroup.sellingPlans.edges.map(
                     (sellingPlan: SellingPlan) => {
                       return (
-                        <li>
+                        <li key={sellingPlan.node.id}>
                           {sellingPlan.node.name}{' '}
                           <em>({sellingPlan.node.id})</em>
                         </li>
@@ -231,67 +283,57 @@ function SellingPlanGroup() {
             </Layout.Section>
             <Layout.AnnotatedSection
               title="Edit"
-              description="Edit Selling Plan"
+              description="You can edit the group name, description and merchant code. As well as the selling plans. Plan names should follow the ex: `Delivered every week (Save 10%)`"
             >
-              <Card sectioned>
+              <Card title="Selling Plan Group" sectioned>
                 <Layout>
                   <Layout.Section>
                     <TextField
-                      value={planTitle}
-                      onChange={planTitle => setPlanTitle(planTitle)}
-                      label="Plan Title"
+                      value={groupName}
+                      onChange={value => handleGroupName(value)}
+                      label="Group Name"
+                      type="text"
+                    />
+                    <TextField
+                      value={groupDescription}
+                      onChange={value => handleGroupDescription(value)}
+                      label="Group Description"
                       type="text"
                     />
                     <TextField
                       value={merchantCode}
-                      onChange={merchantCode => setMerchantCode(merchantCode)}
+                      onChange={value => handleMerchantCode(value)}
                       label="Merchant Code"
                       type="text"
-                    />
-                    <TextField
-                      value={options}
-                      onChange={options => setOptions(options)}
-                      label="Options"
-                      type="text"
-                    />
-                  </Layout.Section>
-                  <Layout.Section>
-                    <Select
-                      label="Interval"
-                      options={[
-                        { label: 'Daily', value: 'DAY' },
-                        { label: 'Weekly', value: 'WEEK' },
-                        { label: 'Monthly', value: 'MONTH' },
-                        { label: 'Yearly', value: 'YEAR' },
-                      ]}
-                      onChange={interval => setInterval(interval)}
-                      value={interval}
-                    />
-                    <TextField
-                      value={percentOff}
-                      onChange={percentOff => setPercentOff(percentOff)}
-                      label="Percent Off (%)"
-                      type="number"
-                    />
-                  </Layout.Section>
-                  <Layout.Section>
-                    <UpdateSellingPlanGroupButton
-                      id={data.sellingPlanGroup.id}
-                      planTitle={planTitle}
-                      percentOff={percentOff}
-                      merchantCode={merchantCode}
-                      interval={interval}
-                      options={options}
-                      sellingPlans={data.sellingPlanGroup.sellingPlans.edges}
-                      toggleActive={toggleActive}
-                      setMsg={setMsg}
-                      setToastError={setToastError}
-                      refetch={refetch}
                     />
                   </Layout.Section>
                 </Layout>
               </Card>
+              {sellingPlans.map((plan: SellingPlan, index: number) => {
+                return (
+                  <UpdateSellingPlanForm
+                    key={plan.node.id}
+                    sellingPlan={plan}
+                    handleSellingPlans={handleSellingPlans}
+                    index={index}
+                  />
+                );
+              })}
             </Layout.AnnotatedSection>
+            <Layout.Section>
+              <UpdateSellingPlanGroupButton
+                id={data.sellingPlanGroup.id}
+                groupName={groupName}
+                groupDescription={groupDescription}
+                merchantCode={merchantCode}
+                options={options}
+                sellingPlans={sellingPlans}
+                toggleActive={toggleActive}
+                setMsg={setMsg}
+                setToastError={setToastError}
+                refetch={refetch}
+              />
+            </Layout.Section>
           </Layout>
           {toastMarkup}
         </Frame>

--- a/app/src/types/sellingplans.d.ts
+++ b/app/src/types/sellingplans.d.ts
@@ -18,13 +18,13 @@ export interface SellingPlan {
     description: string;
     options: string[];
     position: number;
-    billingPolicty: {
+    billingPolicy: {
       interval: string;
       intervalCount: number;
     };
     deliveryPolicy: {
       interval: string;
-      intervalcount: number;
+      intervalCount: number;
     };
     pricingPolicies: [
       {


### PR DESCRIPTION
Updated Selling Plan Group Shopify Admin App view.  User can now edit selling plan group, name, description and selling plans individually.